### PR TITLE
New functionality and links for tiles

### DIFF
--- a/src/HomePageComponents/Header.jsx
+++ b/src/HomePageComponents/Header.jsx
@@ -81,8 +81,8 @@ export default function Header(props) {
               to={{
                 pathname: `/profile/${userInfo.uid}`,
                 state: {
-                  userId: userInfo.uid
-                }
+                  userId: userInfo.uid,
+                },
               }}
               style={navStyle}
             >
@@ -92,7 +92,7 @@ export default function Header(props) {
         </div>
 
         <Link key="donations" to="/donations" style={navStyle}>
-          Donations
+          Requests & Donations
         </Link>
         <Link key="charities" to="/charities" style={navStyle}>
           Charities
@@ -106,8 +106,8 @@ export default function Header(props) {
               to={{
                 pathname: `/chat/${userInfo.uid}`,
                 state: {
-                  userId: userInfo.uid
-                }
+                  userId: userInfo.uid,
+                },
               }}
               style={navStyle}
             >

--- a/src/components/SearchDonations.jsx
+++ b/src/components/SearchDonations.jsx
@@ -52,6 +52,7 @@ const SearchOrgs = () => {
                 checked={switchState}
                 onChange={handleSwitch}
                 name="search-type"
+                color="primary"
               />
             </Grid>
             <Grid item>Donations</Grid>

--- a/src/components/tiles/OfferTile.jsx
+++ b/src/components/tiles/OfferTile.jsx
@@ -142,8 +142,8 @@ const OfferTile = ({ doc }) => {
             >
               <CardMedia
                 className={classes.media}
-                image="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTlHWg74rYh0ee1LQPLhyQxGFTxg4YBGMSUJQ&usqp=CAU"
-                title="Paella dish"
+                image={`https://source.unsplash.com/600x400/?${title}`}
+                title="charitable donation"
               />
             </Link>
 

--- a/src/components/tiles/OfferTile.jsx
+++ b/src/components/tiles/OfferTile.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { Link } from 'react-router-dom';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 import ForumIcon from '@material-ui/icons/Forum';
@@ -18,6 +18,7 @@ import {
 } from '@material-ui/core';
 import firestore from '../../db/firebase';
 import { convertMsToDays } from '../../utils/moment';
+import UserContext from '../../contexts/UserContext';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -47,6 +48,7 @@ const useStyles = makeStyles((theme) => ({
 
 const OfferTile = ({ doc }) => {
   const classes = useStyles();
+  const { userInfo } = useContext(UserContext);
   const { donor_id, title, description, quantity, date, expiry, id } = doc;
 
   const [donor, setDonor] = useState({});
@@ -95,9 +97,13 @@ const OfferTile = ({ doc }) => {
                     },
                   }}
                 >
-                  <IconButton aria-label="chat">
-                    <ForumIcon />
-                  </IconButton>
+                  {userInfo && userInfo.uid ? (
+                    <IconButton aria-label="chat">
+                      <ForumIcon />
+                    </IconButton>
+                  ) : (
+                    <></>
+                  )}
                 </Link>
               }
               title={

--- a/src/components/tiles/OfferTile.jsx
+++ b/src/components/tiles/OfferTile.jsx
@@ -106,24 +106,7 @@ const OfferTile = ({ doc }) => {
                   )}
                 </Link>
               }
-              title={
-                <Link
-                  key="donationDetail"
-                  to={{
-                    pathname: `/donations/${id}`,
-                    state: {
-                      productId: id,
-                      userId: donor_id,
-                      title: title,
-                      description: description,
-                      quantity: quantity,
-                      date: date,
-                    },
-                  }}
-                >
-                  {`${title} (x${quantity})`}
-                </Link>
-              }
+              title={`${title} (x${quantity})`}
               subheader={donor.name}
             />
             <Link
@@ -146,12 +129,28 @@ const OfferTile = ({ doc }) => {
                 title="charitable donation"
               />
             </Link>
-
-            <CardContent className={classes.content}>
-              <Typography variant="body2" color="textSecondary">
-                {description}
-              </Typography>
-            </CardContent>
+            <Link
+              style={{ textDecoration: 'none' }}
+              key="donationDetail"
+              to={{
+                pathname: `/donations/${id}`,
+                state: {
+                  context: 'users',
+                  productId: id,
+                  userId: donor_id,
+                  title,
+                  description,
+                  quantity,
+                  date,
+                },
+              }}
+            >
+              <CardContent className={classes.content}>
+                <Typography variant="body2" color="textSecondary">
+                  {description}
+                </Typography>
+              </CardContent>
+            </Link>
 
             <CardActions className={classes.cardactions}>
               <Typography variant="overline">

--- a/src/components/tiles/RequestTile.jsx
+++ b/src/components/tiles/RequestTile.jsx
@@ -117,6 +117,7 @@ const RequestTile = ({ doc }) => {
                   )}
                 </Link>
               }
+              title={title}
               subheader={org.name}
             />
 

--- a/src/components/tiles/RequestTile.jsx
+++ b/src/components/tiles/RequestTile.jsx
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 import React, { useState, useEffect, useContext } from 'react';
-=======
-import React, { useState, useEffect } from 'react';
->>>>>>> main
 import { Link } from 'react-router-dom';
 
 import {
@@ -72,33 +68,33 @@ const RequestTile = ({ doc }) => {
               avatar={
                 emergency ? (
                   <Link
-                  key="charity"
-                  to={{
-                    pathname: `/charities/${org_id}`,
-                    state: {
-                      userId: org_id,
-                      type: "charity"
-                    },
-                  }}
-                >
-                  <Avatar aria-label="request" className={classes.avatar}>
-                    <LocationCityIcon />
-                  </Avatar>
+                    key="charity"
+                    to={{
+                      pathname: `/charities/${org_id}`,
+                      state: {
+                        userId: org_id,
+                        type: 'charity',
+                      },
+                    }}
+                  >
+                    <Avatar aria-label="request" className={classes.avatar}>
+                      <LocationCityIcon />
+                    </Avatar>
                   </Link>
                 ) : (
                   <Link
-                  key="charity"
-                  to={{
-                    pathname: `/charities/${org_id}`,
-                    state: {
-                      userId: org_id,
-                      type: "charity"
-                    },
-                  }}
-                >
-                  <Avatar aria-label="request" className={classes.avatarEmg}>
-                    <NotificationImportantIcon />
-                  </Avatar>
+                    key="charity"
+                    to={{
+                      pathname: `/charities/${org_id}`,
+                      state: {
+                        userId: org_id,
+                        type: 'charity',
+                      },
+                    }}
+                  >
+                    <Avatar aria-label="request" className={classes.avatarEmg}>
+                      <NotificationImportantIcon />
+                    </Avatar>
                   </Link>
                 )
               }
@@ -112,7 +108,6 @@ const RequestTile = ({ doc }) => {
                     },
                   }}
                 >
-<<<<<<< HEAD
                   {userInfo && userInfo.uid ? (
                     <IconButton aria-label="chat">
                       <ForumIcon />
@@ -120,30 +115,6 @@ const RequestTile = ({ doc }) => {
                   ) : (
                     <></>
                   )}
-=======
-                <IconButton aria-label="chat">
-                  <ForumIcon />
-                </IconButton>
-                </Link>
-              }
-              title={
-                <Link
-                  key="donationDetail"
-                  to={{
-                    pathname: `/donations/${id}`,
-                    state: {
-                      productId: id,
-                      userId: org_id,
-                      title: title,
-                      emergency: emergency,
-                      description: description,
-                      quantity: quantity,
-                      date: date,
-                    },
-                  }}
-                >
-                {`${title} (x${quantity})`}
->>>>>>> main
                 </Link>
               }
               subheader={org.name}

--- a/src/components/tiles/RequestTile.jsx
+++ b/src/components/tiles/RequestTile.jsx
@@ -121,11 +121,28 @@ const RequestTile = ({ doc }) => {
               subheader={org.name}
             />
 
-            <CardContent className={classes.content}>
-              <Typography variant="body2" color="textSecondary">
-                {description}
-              </Typography>
-            </CardContent>
+            <Link
+              style={{ textDecoration: 'none' }}
+              key="donationDetail"
+              to={{
+                pathname: `/donations/${id}`,
+                state: {
+                  context: 'organizations',
+                  productId: id,
+                  userId: org_id,
+                  title,
+                  description,
+                  quantity,
+                  date,
+                },
+              }}
+            >
+              <CardContent className={classes.content}>
+                <Typography variant="body2" color="textSecondary">
+                  {description}
+                </Typography>
+              </CardContent>
+            </Link>
 
             <CardActions className={classes.cardactions}>
               <Typography variant="overline">

--- a/src/components/tiles/RequestTile.jsx
+++ b/src/components/tiles/RequestTile.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
+import { Link } from 'react-router-dom';
 
 import {
   makeStyles,
@@ -16,7 +17,7 @@ import {
 import LocationCityIcon from '@material-ui/icons/LocationCity';
 import NotificationImportantIcon from '@material-ui/icons/NotificationImportant';
 import ForumIcon from '@material-ui/icons/Forum';
-
+import UserContext from '../../contexts/UserContext';
 import firestore from '../../db/firebase';
 
 const useStyles = makeStyles((theme) => ({
@@ -40,6 +41,7 @@ const useStyles = makeStyles((theme) => ({
 
 const RequestTile = ({ doc }) => {
   const classes = useStyles();
+  const { userInfo } = useContext(UserContext);
   const { org_id, title, description, quantity, emergency, date } = doc;
 
   const [org, setOrg] = useState({});
@@ -75,9 +77,23 @@ const RequestTile = ({ doc }) => {
                 )
               }
               action={
-                <IconButton aria-label="chat">
-                  <ForumIcon />
-                </IconButton>
+                <Link
+                  key="chat"
+                  to={{
+                    pathname: `/chat/${org_id}`,
+                    state: {
+                      userId: org_id,
+                    },
+                  }}
+                >
+                  {userInfo && userInfo.uid ? (
+                    <IconButton aria-label="chat">
+                      <ForumIcon />
+                    </IconButton>
+                  ) : (
+                    <></>
+                  )}
+                </Link>
               }
               title={`${title} (x${quantity})`}
               subheader={org.name}

--- a/src/details/donations.jsx
+++ b/src/details/donations.jsx
@@ -1,66 +1,77 @@
 import React from 'react';
-import { Avatar, Button, Grid, makeStyles, TextField, Typography } from '@material-ui/core';
+import {
+  Avatar,
+  Button,
+  Grid,
+  makeStyles,
+  TextField,
+  Typography,
+} from '@material-ui/core';
 import SendIcon from '@material-ui/icons/Send';
 
 // PROPS PASSED FROM ROUTER
-import { BrowserRouter as Router, Switch, useLocation } from "react-router-dom";
+import { BrowserRouter as Router, Switch, useLocation } from 'react-router-dom';
 
 const useStyles = makeStyles((theme) => ({
   root: {
     display: 'flex',
     '& > *': {
       margin: theme.spacing(1),
-    }
+    },
   },
   center: {
     display: 'flex',
-    justifyContent: 'center'
+    justifyContent: 'center',
   },
   large: {
     width: theme.spacing(15),
-    height: theme.spacing(15)
+    height: theme.spacing(15),
   },
   textFieldWidth: {
-    width: 800
+    width: 800,
   },
   button: {
     marginTop: '20px',
     width: '175px',
-    margin: 'auto'
-  }
+    margin: 'auto',
+  },
 }));
 
 export default function Donations() {
   const location = useLocation();
-  const {productId, userId, title, description, quantity, date} = location.state;
-
+  const { context, productId, userId, title, description, quantity, date } =
+    location.state;
+  // Pep: Added {context} prop that resolves to 'organizations' if user being sent from a RequestTile, and 'users' if coming from OfferTile
+  // console.log('link context:', context);
   const classes = useStyles();
-  const dummyProfPic = "https://images.unsplash.com/photo-1488521787991-ed7bbaae773c?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80";
+  const dummyProfPic =
+    'https://images.unsplash.com/photo-1488521787991-ed7bbaae773c?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1050&q=80';
   const dummyDonorName = 'Bobby';
-  const dummyDonorDetails = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
+  const dummyDonorDetails =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
 
   return (
     <>
       <Grid container>
         <Grid item xs={3}>
           <div className={classes.root}>
-            <Avatar alt="profile pic" src={dummyProfPic} className={classes.large}/>
+            <Avatar
+              alt="profile pic"
+              src={dummyProfPic}
+              className={classes.large}
+            />
           </div>
         </Grid>
         <Grid item xs={9}>
-          <Typography variant="h3">
-            Details about {dummyDonorName}
-          </Typography>
-          <Typography variant="caption">
-            {dummyDonorDetails}
-          </Typography>
+          <Typography variant="h3">Details about {dummyDonorName}</Typography>
+          <Typography variant="caption">{dummyDonorDetails}</Typography>
         </Grid>
       </Grid>
       <Grid item className={classes.center}>
         <Typography variant="h1">LEAVE A MESSAGE</Typography>
       </Grid>
 
-        {/* <Desks/> Return to me! */}
+      {/* <Desks/> Return to me! */}
       <Grid container direction="column">
         <Grid item className={classes.center}>
           <Typography variant="h6">Title</Typography>
@@ -69,7 +80,8 @@ export default function Donations() {
           <TextField
             label="Title..."
             variant="outlined"
-            className={classes.textFieldWidth}/>
+            className={classes.textFieldWidth}
+          />
         </Grid>
         <Grid item className={classes.center}>
           <Typography variant="h6">Message</Typography>
@@ -80,7 +92,8 @@ export default function Donations() {
             variant="outlined"
             multiline
             rows={4}
-            className={classes.textFieldWidth}/>
+            className={classes.textFieldWidth}
+          />
         </Grid>
         <Button
           variant="contained"
@@ -92,6 +105,5 @@ export default function Donations() {
         </Button>
       </Grid>
     </>
-  )
+  );
 }
-


### PR DESCRIPTION
New tiles-specific features:

- Chat buttons on tiles only appear if current user is logged in.
- Clicking on tile bodies (image or description) route to @dylanreid7's `Donations` component. When clicked, each tile now also passes a {context} prop that resolves to 'organizations' if user is coming from a RequestTile, and to 'users'  if user is coming from an OfferTile.
-  For now, each RequestTile is fetching a random unsplash placeholder image specific to the request title. This slows down performance, but we can at least maybe make better styling choices based on actual images.