### PR TITLE
Details page bug fixes.

### DIFF
--- a/src/components/details/Map.jsx
+++ b/src/components/details/Map.jsx
@@ -22,7 +22,7 @@ export default function Map({ zip, pic }) {
     <div
       style={{
         width: '80%',
-        height: '300px',
+        height: '500px',
         display: 'flex',
         margin: 'auto',
         marginTop: '20px',

--- a/src/components/details/Offer.jsx
+++ b/src/components/details/Offer.jsx
@@ -31,6 +31,7 @@ const useStyles = makeStyles((theme) => ({
   image: {
     border: '2px solid black',
     height: 250,
+    maxWidth: 450,
     display: 'flex',
     justifyContent: 'center',
     borderRadius: '20px',
@@ -82,14 +83,17 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center'
   },
   height1: {
-    height: '30%'
+    paddingTop: 15
   },
   height2: {
-    height: '50%'
+    paddingTop: 20,
+    paddingRight: 20
   },
   height3: {
-    height: '20%',
-    alignItems: 'center'
+    // height: '20%',
+    // alignItems: 'center'
+    position: 'absolute',
+    bottom: 20
   },
   avatarSpacing: {
     paddingLeft: 30
@@ -100,13 +104,17 @@ const useStyles = makeStyles((theme) => ({
   },
   descSpacing: {
     paddingTop: 10
+  },
+  relative: {
+    position: 'relative'
   }
 }));
 
 export default function Offer({ doc }) {
   const classes = useStyles();
-  const { productId, userId, title, imgURL, description, quantity, date } = doc;
+  const { productId, userId, title, description, quantity, date } = doc;
   const formattedDate = timeAgo.format(new Date(date.seconds * 1000));
+  let imgURL = doc.imgURL || `https://source.unsplash.com/400x200/?${title}`;
   const [donor, setDonor] = useState({});
 
   useEffect(() => {
@@ -132,7 +140,7 @@ export default function Offer({ doc }) {
             }
           </Grid>
           <Grid container item xs={6}>
-            <Grid container direction="column">
+            <Grid container direction="column" className={classes.relative}>
               <Grid container direction="row" className={classes.height1}>
                 <Grid item xs={6} className={classes.title}>
                   <Typography variant="h3">

--- a/src/components/details/Request.jsx
+++ b/src/components/details/Request.jsx
@@ -82,14 +82,17 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center'
   },
   height1: {
-    height: '30%'
+    // height: '30%'
   },
   height2: {
-    height: '50%'
+    paddingTop: 20,
+    paddingRight: 20
   },
   height3: {
-    height: '20%',
-    alignItems: 'center'
+    // height: '20%',
+    // alignItems: 'center'
+    position: 'absolute',
+    bottom: 20
   },
   avatarSpacing: {
     paddingLeft: 30
@@ -109,6 +112,9 @@ const useStyles = makeStyles((theme) => ({
   redText: {
     color: 'red',
     paddingLeft: 4
+  },
+  relative: {
+    position: 'relative'
   }
 }));
 
@@ -150,7 +156,7 @@ export default function Request({ doc }) {
             }
           </Grid>
           <Grid container item xs={6}>
-            <Grid container direction="column">
+            <Grid container direction="column" className={classes.relative}>
               {emergency ?
               <Grid container direction="row" className={classes.height1}>
                 <Grid item xs={6} className={classes.title}>


### PR DESCRIPTION
- Images are sized down if they are super wide.
- The title of the offer/request spills over onto a second line and everything adjust. Previously, it looked super glitchy if there was a long title.
- Revised the imgURL so that it either pulls in the actual url it is passed, or searches unsplash, like Pep's cards.
- Revised the height of the map.